### PR TITLE
Add Fly.io deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+tests/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Test & Deploy to Fly
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt && pytest
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    FLASK_APP=app.py
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV DATABASE_URL=sqlite:////data/app.db
+
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "app:app"]

--- a/app.py
+++ b/app.py
@@ -1,10 +1,20 @@
+import os
 import sqlite3
 from flask import Flask, render_template, request, redirect, url_for
 
 app = Flask(__name__)
 
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:////data/app.db")
+
+def _db_path(url: str) -> str:
+    if url.startswith("sqlite:///"):
+        return url[len("sqlite:///") :]
+    if url.startswith("sqlite:////"):
+        return "/" + url[len("sqlite:////") :]
+    return url
+
 def get_db_connection():
-    conn = sqlite3.connect('shots.db')
+    conn = sqlite3.connect(_db_path(DATABASE_URL))
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -50,4 +60,4 @@ def increment(player_id):
 
 if __name__ == '__main__':
     init_db()
-    app.run(host='0.0.0.0', port=5000)
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,12 @@
+app = "example-app-name"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https   = true
+
+[[mounts]]
+  source      = "data"
+  destination = "/data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.3.2
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore for container builds
- configure Fly.io via `fly.toml`
- add GitHub Actions workflow for deployment
- allow DB path and port from environment in `app.py`
- include `gunicorn` in requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866b5db5410832e89b6dc4dd9efc981