### PR TITLE
Fix Fly.io deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt && pytest
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v0.3.145
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- pin Fly CLI action to stable release

## Testing
- `pytest -q`
- `flyctl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bbac1b04832e9afd3bfb9c4c91dc