### PR TITLE
Fix missing DB init after deploy

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,11 @@ def init_db():
     conn.commit()
     conn.close()
 
+@app.before_first_request
+def _init_db_if_needed():
+    """Ensure the database schema exists before handling requests."""
+    init_db()
+
 @app.route('/')
 def index():
     conn = get_db_connection()


### PR DESCRIPTION
## Summary
- ensure the DB schema is created when the server starts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866bea18354832eb564291544c45c58